### PR TITLE
fix: keep emoji and non-Latin names intact in avatar placeholder

### DIFF
--- a/lib/widgets/avatar.dart
+++ b/lib/widgets/avatar.dart
@@ -159,7 +159,7 @@ class _AvatarVisuals extends StatelessWidget {
     final displayName = name;
     final fallbackLetters = (displayName == null || displayName.isEmpty)
         ? '@'
-        : displayName.substring(0, 1);
+        : displayName.characters.first;
 
     return Container(
       decoration: BoxDecoration(


### PR DESCRIPTION
The fallback avatar took the first letter via displayName.substring(0, 1), which slices the string at the first UTF-16 code unit. When a display name starts with an emoji or any character outside the BMP, that splits the surrogate pair and the placeholder shows a broken glyph instead of the intended character.

Grab the first grapheme cluster with characters.first so emoji and multi-byte names render correctly.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS