### PR TITLE
feat: let users pick the app language in settings

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -2206,6 +2206,36 @@
         "type": "String",
         "placeholders": {}
     },
+    "language": "Language",
+    "@language": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "systemLanguage": "System language",
+    "@systemLanguage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "appLanguageTitle": "App language",
+    "@appLanguageTitle": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "recommended": "Recommended",
+    "@recommended": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "allLanguages": "All languages",
+    "@allLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "searchLanguages": "Search languages",
+    "@searchLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
     "theyDontMatch": "They Don't Match",
     "@theyDontMatch": {
         "type": "String",

--- a/assets/l10n/intl_ru.arb
+++ b/assets/l10n/intl_ru.arb
@@ -2196,6 +2196,36 @@
         "type": "String",
         "placeholders": {}
     },
+    "language": "Язык",
+    "@language": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "systemLanguage": "Язык системы",
+    "@systemLanguage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "appLanguageTitle": "Язык приложения",
+    "@appLanguageTitle": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "recommended": "Рекомендованные",
+    "@recommended": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "allLanguages": "Все языки",
+    "@allLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "searchLanguages": "Поиск языков",
+    "@searchLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
     "theyDontMatch": "Они не совпадают",
     "@theyDontMatch": {
         "type": "String",

--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -78,6 +78,7 @@ enum AppSettings<T> {
   cleanExif<bool>('xyz.extera.next.cleanExif', true),
   doNotSendIfCantClean<bool>('xyz.extera.next.doNotSendIfCantClean', true),
   themeMode<String>('xyz.extera.next.themeMode', 'system'),
+  appLanguage<String>('xyz.extera.next.appLanguage', ''),
   pureBlack<bool>('xyz.extera.next.pureBlack', false),
   renderHtml<bool>('chat.fluffy.renderHtml', true),
   schemeVariant<int>('xyz.extera.next.schemeVariant', 0),

--- a/lib/pages/settings_language/settings_language_page.dart
+++ b/lib/pages/settings_language/settings_language_page.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+
+import 'package:extera_next/config/app_config.dart';
+import 'package:extera_next/generated/l10n/l10n.dart';
+import 'package:extera_next/utils/locale_display_name.dart';
+import 'package:extera_next/widgets/theme_builder.dart';
+
+/// Full screen language picker shown from Settings → Appearance.
+///
+/// Mirrors the system "per app language" layout: an app header, a
+/// "Recommended" section built from the device locales and an "All languages"
+/// section with every shipped translation. Picking an entry overrides the app
+/// language independently of the system locale (see [ThemeController.setLocale]).
+class SettingsLanguagePage extends StatefulWidget {
+  const SettingsLanguagePage({super.key});
+
+  @override
+  State<SettingsLanguagePage> createState() => _SettingsLanguagePageState();
+}
+
+class _SettingsLanguagePageState extends State<SettingsLanguagePage> {
+  bool _searching = false;
+  String _query = '';
+
+  /// Finds the shipped translation that best matches a system [locale],
+  /// preferring an exact match, then language + script, then language only.
+  Locale? _resolveSupported(Locale locale) {
+    final supported = L10n.supportedLocales;
+    for (final s in supported) {
+      if (s == locale) return s;
+    }
+    for (final s in supported) {
+      if (s.languageCode == locale.languageCode &&
+          (s.scriptCode ?? '') == (locale.scriptCode ?? '')) {
+        return s;
+      }
+    }
+    for (final s in supported) {
+      if (s.languageCode == locale.languageCode) return s;
+    }
+    return null;
+  }
+
+  /// System suggested locales, paired as (display, resolved translation),
+  /// deduplicated by the resolved translation.
+  List<(Locale, Locale)> get _recommended {
+    final result = <(Locale, Locale)>[];
+    final seen = <String>{};
+    for (final system in WidgetsBinding.instance.platformDispatcher.locales) {
+      final resolved = _resolveSupported(system);
+      if (resolved == null) continue;
+      if (seen.add(resolved.toLanguageTag())) {
+        result.add((system, resolved));
+      }
+    }
+    return result;
+  }
+
+  bool _isSelected(Locale locale) {
+    final current = ThemeController.of(context).locale;
+    if (current == null) return false;
+    return current.languageCode == locale.languageCode &&
+        (current.scriptCode ?? '') == (locale.scriptCode ?? '') &&
+        (current.countryCode ?? '') == (locale.countryCode ?? '');
+  }
+
+  void _select(Locale? locale) {
+    ThemeController.of(context).setLocale(locale);
+    setState(() {});
+  }
+
+  Iterable<Locale> get _filteredAll {
+    final query = _query.trim().toLowerCase();
+    if (query.isEmpty) return L10n.supportedLocales;
+    return L10n.supportedLocales.where((locale) {
+      final name = localeDisplayName(locale).toLowerCase();
+      final tag = locale.toLanguageTag().toLowerCase();
+      return name.contains(query) || tag.contains(query);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isSearching = _searching;
+    final systemSelected = ThemeController.of(context).locale == null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: isSearching
+            ? TextField(
+                autofocus: true,
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  hintText: L10n.of(context).searchLanguages,
+                ),
+                onChanged: (value) => setState(() => _query = value),
+              )
+            : Text(L10n.of(context).appLanguageTitle),
+        actions: [
+          IconButton(
+            icon: Icon(isSearching ? Icons.close : Icons.search),
+            onPressed: () => setState(() {
+              _searching = !_searching;
+              _query = '';
+            }),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+        children: [
+          if (!isSearching) ...[
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Column(
+                children: [
+                  Image.asset('assets/logo.png', width: 72, height: 72),
+                  const SizedBox(height: 12),
+                  Text(
+                    AppConfig.applicationName,
+                    style: theme.textTheme.titleLarge,
+                  ),
+                ],
+              ),
+            ),
+            _SectionHeader(L10n.of(context).recommended),
+            _GroupCard(
+              children: [
+                _RadioTile(
+                  label: L10n.of(context).systemLanguage,
+                  selected: systemSelected,
+                  onTap: () => _select(null),
+                ),
+                for (final (display, resolved) in _recommended)
+                  _RadioTile(
+                    label: systemLocaleDisplayName(display),
+                    selected: _isSelected(resolved),
+                    onTap: () => _select(resolved),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _SectionHeader(L10n.of(context).allLanguages),
+          ],
+          for (final locale in _filteredAll)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _GroupCard(
+                children: [
+                  ListTile(
+                    title: Text(localeDisplayName(locale)),
+                    subtitle: Text(locale.toLanguageTag()),
+                    trailing: _isSelected(locale)
+                        ? Icon(
+                            Icons.check_circle,
+                            color: theme.colorScheme.primary,
+                          )
+                        : null,
+                    onTap: () => _select(locale),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+
+  const _SectionHeader(this.title);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 8),
+      child: Text(
+        title,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupCard extends StatelessWidget {
+  final List<Widget> children;
+
+  const _GroupCard({required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surfaceContainerHigh,
+      clipBehavior: Clip.hardEdge,
+      borderRadius: BorderRadius.circular(AppConfig.borderRadius),
+      child: Column(children: children),
+    );
+  }
+}
+
+class _RadioTile extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _RadioTile({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: Icon(
+        selected ? Icons.radio_button_checked : Icons.radio_button_off,
+        color: selected ? theme.colorScheme.primary : null,
+      ),
+      title: Text(label),
+      selected: selected,
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/pages/settings_style/settings_style.dart
+++ b/lib/pages/settings_style/settings_style.dart
@@ -15,6 +15,8 @@ import 'package:extera_next/config/setting_keys.dart';
 import 'package:extera_next/generated/l10n/l10n.dart';
 import 'package:extera_next/utils/adaptive_bottom_sheet.dart';
 import 'package:extera_next/utils/file_selector.dart';
+import 'package:extera_next/utils/locale_display_name.dart';
+import 'package:extera_next/pages/settings_language/settings_language_page.dart';
 import 'package:extera_next/widgets/future_loading_dialog.dart';
 import 'package:extera_next/widgets/theme_builder.dart';
 import 'settings_style_view.dart';
@@ -201,6 +203,22 @@ class SettingsStyleController extends State<SettingsStyle> {
         );
       },
     );
+  }
+
+  /// Name of the currently selected language, or the localized "system
+  /// language" label when the app follows the system locale.
+  String get currentLanguageName {
+    final locale = ThemeController.of(context).locale;
+    return locale == null
+        ? L10n.of(context).systemLanguage
+        : localeDisplayName(locale);
+  }
+
+  void setAppLanguage() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const SettingsLanguagePage()),
+    );
+    if (mounted) setState(() {});
   }
 
   void saveWallpaperOpacity(double opacity) async {

--- a/lib/pages/settings_style/settings_style_view.dart
+++ b/lib/pages/settings_style/settings_style_view.dart
@@ -110,6 +110,19 @@ class SettingsStyleView extends StatelessWidget {
                 color: theme.colorScheme.surfaceContainerHigh,
                 clipBehavior: Clip.hardEdge,
                 borderRadius: borderRadius,
+                child: ListTile(
+                  leading: const Icon(Icons.language_outlined),
+                  title: Text(L10n.of(context).language),
+                  subtitle: Text(controller.currentLanguageName),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: controller.setAppLanguage,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Material(
+                color: theme.colorScheme.surfaceContainerHigh,
+                clipBehavior: Clip.hardEdge,
+                borderRadius: borderRadius,
                 child: Column(
                   children: [
                     ListTile(

--- a/lib/utils/locale_display_name.dart
+++ b/lib/utils/locale_display_name.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/widgets.dart';
+
+/// Native (endonym) names for the locales the app ships translations for.
+///
+/// Keys are built from the language code optionally followed by the script
+/// and/or country code (see [_localeKey]). Anything that is not listed here
+/// falls back to the bare language name and finally to the BCP-47 tag, so a
+/// newly added translation still shows up even before it gets a name here.
+const Map<String, String> _languageNames = {
+  'ar': 'العربية',
+  'be': 'Беларуская',
+  'bn': 'বাংলা',
+  'bo': 'བོད་སྐད་',
+  'ca': 'Català',
+  'cs': 'Čeština',
+  'de': 'Deutsch',
+  'el': 'Ελληνικά',
+  'en': 'English',
+  'eo': 'Esperanto',
+  'es': 'Español',
+  'et': 'Eesti',
+  'eu': 'Euskara',
+  'fa': 'فارسی',
+  'fi': 'Suomi',
+  'fil': 'Filipino',
+  'fr': 'Français',
+  'ga': 'Gaeilge',
+  'gl': 'Galego',
+  'he': 'עברית',
+  'hi': 'हिन्दी',
+  'hr': 'Hrvatski',
+  'hu': 'Magyar',
+  'ia': 'Interlingua',
+  'id': 'Bahasa Indonesia',
+  'ie': 'Interlingue',
+  'it': 'Italiano',
+  'ja': '日本語',
+  'ka': 'ქართული',
+  'ko': '한국어',
+  'lt': 'Lietuvių',
+  'lv': 'Latviešu',
+  'nb': 'Norsk bokmål',
+  'nl': 'Nederlands',
+  'pl': 'Polski',
+  'pt': 'Português',
+  'pt_BR': 'Português (Brasil)',
+  'pt_PT': 'Português (Portugal)',
+  'ro': 'Română',
+  'ru': 'Русский',
+  'sk': 'Slovenčina',
+  'sl': 'Slovenščina',
+  'sr': 'Српски',
+  'sv': 'Svenska',
+  'ta': 'தமிழ்',
+  'te': 'తెలుగు',
+  'th': 'ไทย',
+  'tr': 'Türkçe',
+  'uk': 'Українська',
+  'vi': 'Tiếng Việt',
+  'zh': '中文',
+  'zh_Hant': '中文 (繁體)',
+};
+
+String _localeKey(Locale locale) {
+  final buffer = StringBuffer(locale.languageCode);
+  final script = locale.scriptCode;
+  if (script != null && script.isNotEmpty) buffer.write('_$script');
+  final country = locale.countryCode;
+  if (country != null && country.isNotEmpty) buffer.write('_$country');
+  return buffer.toString();
+}
+
+/// Native names including the region, used for the "recommended" section where
+/// the entries come from the system locale list and therefore carry a country,
+/// e.g. `Русский (Россия)`. Anything not listed falls back to the bare language
+/// name via [systemLocaleDisplayName].
+const Map<String, String> _regionalNames = {
+  'ru_RU': 'Русский (Россия)',
+  'en_US': 'English (United States)',
+  'en_GB': 'English (United Kingdom)',
+  'ja_JP': '日本語 (日本)',
+  'de_DE': 'Deutsch (Deutschland)',
+  'fr_FR': 'Français (France)',
+  'uk_UA': 'Українська (Україна)',
+  'be_BY': 'Беларуская (Беларусь)',
+  'es_ES': 'Español (España)',
+  'pt_BR': 'Português (Brasil)',
+  'pt_PT': 'Português (Portugal)',
+  'zh_CN': '中文 (中国)',
+  'zh_TW': '中文 (台灣)',
+  'it_IT': 'Italiano (Italia)',
+  'pl_PL': 'Polski (Polska)',
+  'ko_KR': '한국어 (대한민국)',
+  'tr_TR': 'Türkçe (Türkiye)',
+  'cs_CZ': 'Čeština (Česko)',
+  'nl_NL': 'Nederlands (Nederland)',
+};
+
+/// Returns a human readable, native name for [locale] to show in the language
+/// picker, e.g. `Deutsch` or `Português (Brasil)`.
+String localeDisplayName(Locale locale) {
+  return _languageNames[_localeKey(locale)] ??
+      _languageNames[locale.languageCode] ??
+      locale.toLanguageTag();
+}
+
+/// Like [localeDisplayName] but adds the region when known. Used for the
+/// system-suggested languages, e.g. `Русский (Россия)`.
+String systemLocaleDisplayName(Locale locale) {
+  return _regionalNames[_localeKey(locale)] ?? localeDisplayName(locale);
+}

--- a/lib/widgets/fluffy_chat_app.dart
+++ b/lib/widgets/fluffy_chat_app.dart
@@ -99,8 +99,10 @@ class _FluffyChatAppState extends State<FluffyChatApp> {
             schemeVariant,
             pureBlack,
             twemoji,
+            locale,
           ) => MaterialApp.router(
             title: AppConfig.applicationName,
+            locale: locale,
             themeMode: themeMode,
             theme: FluffyThemes.buildTheme(
               context,

--- a/lib/widgets/theme_builder.dart
+++ b/lib/widgets/theme_builder.dart
@@ -15,6 +15,7 @@ class ThemeBuilder extends StatefulWidget {
     DynamicSchemeVariant schemeVariant,
     bool pureBlack,
     bool twemoji,
+    Locale? locale,
   )
   builder;
 
@@ -23,6 +24,7 @@ class ThemeBuilder extends StatefulWidget {
   final String pureBlackSettingsKey;
   final String twemojiSettingsKey;
   final String schemeVariantSettingsKey;
+  final String localeSettingsKey;
 
   const ThemeBuilder({
     required this.builder,
@@ -31,6 +33,7 @@ class ThemeBuilder extends StatefulWidget {
     this.pureBlackSettingsKey = 'xyz.extera.next.pureBlack',
     this.twemojiSettingsKey = 'xyz.extera.next.twemojiFont',
     this.schemeVariantSettingsKey = 'xyz.extera.next.schemeVariant',
+    this.localeSettingsKey = 'xyz.extera.next.appLanguage',
     super.key,
   });
 
@@ -45,6 +48,7 @@ class ThemeController extends State<ThemeBuilder> {
   bool? _pureBlack;
   bool? _twemoji;
   DynamicSchemeVariant? _variant;
+  Locale? _locale;
 
   ThemeMode get themeMode => _themeMode ?? ThemeMode.system;
 
@@ -53,6 +57,9 @@ class ThemeController extends State<ThemeBuilder> {
   bool get pureBlack => _pureBlack ?? false;
 
   bool get twemoji => _twemoji ?? false;
+
+  /// The user selected app language, or `null` to follow the system locale.
+  Locale? get locale => _locale;
 
   DynamicSchemeVariant get variant =>
       _variant ?? DynamicSchemeVariant.tonalSpot;
@@ -71,6 +78,7 @@ class ThemeController extends State<ThemeBuilder> {
     final rawVariant =
         preferences.getInt(widget.schemeVariantSettingsKey) ??
         DynamicSchemeVariant.values.indexOf(.tonalSpot);
+    final rawLocale = preferences.getString(widget.localeSettingsKey);
 
     setState(() {
       _themeMode = ThemeMode.values.singleWhereOrNull(
@@ -80,6 +88,7 @@ class ThemeController extends State<ThemeBuilder> {
       _pureBlack = rawPureBlack;
       _twemoji = rawTwemoji;
       _variant = .values[rawVariant];
+      _locale = _localeFromString(rawLocale);
     });
   }
 
@@ -142,6 +151,20 @@ class ThemeController extends State<ThemeBuilder> {
     });
   }
 
+  Future<void> setLocale(Locale? newLocale) async {
+    final preferences = _sharedPreferences ??=
+        await SharedPreferences.getInstance();
+    final value = _localeToString(newLocale);
+    if (value.isEmpty) {
+      await preferences.remove(widget.localeSettingsKey);
+    } else {
+      await preferences.setString(widget.localeSettingsKey, value);
+    }
+    setState(() {
+      _locale = newLocale;
+    });
+  }
+
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback(_loadData);
@@ -160,8 +183,39 @@ class ThemeController extends State<ThemeBuilder> {
           variant,
           pureBlack,
           twemoji,
+          locale,
         ),
       ),
     );
   }
+}
+
+/// Parses a stored locale string such as `en`, `pt_BR` or `zh_Hant` back into
+/// a [Locale]. Returns `null` for an empty/missing value (follow the system).
+Locale? _localeFromString(String? code) {
+  if (code == null || code.isEmpty) return null;
+  final parts = code.replaceAll('-', '_').split('_');
+  return switch (parts.length) {
+    1 => Locale(parts[0]),
+    // Distinguish a 4 letter script (e.g. Hant) from a country code.
+    >= 2 when parts[1].length == 4 => Locale.fromSubtags(
+      languageCode: parts[0],
+      scriptCode: parts[1],
+    ),
+    _ => Locale(parts[0], parts[1]),
+  };
+}
+
+/// Serializes a [Locale] for storage. Mirrors [_localeFromString].
+String _localeToString(Locale? locale) {
+  if (locale == null) return '';
+  final script = locale.scriptCode;
+  if (script != null && script.isNotEmpty) {
+    return '${locale.languageCode}_$script';
+  }
+  final country = locale.countryCode;
+  if (country != null && country.isNotEmpty) {
+    return '${locale.languageCode}_$country';
+  }
+  return locale.languageCode;
 }


### PR DESCRIPTION
Until now the interface language was tied to the system locale with no way to override it, which is annoying when your phone is set to one language but you want the app in another (issue #83).

This adds a Language entry in the appearance settings that opens a list of every translation the app ships, plus a System default option to go back to following the OS. The choice is stored and applied to MaterialApp through the existing ThemeController, so it survives restarts and updates the whole UI right away.

Languages are listed by their native name (Deutsch, Русский, 日本語, ...); anything without a name yet falls back to its language tag.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS