### PR TITLE
Enable native spell check #156

### DIFF
--- a/lib/pages/chat/chat_input_row.dart
+++ b/lib/pages/chat/chat_input_row.dart
@@ -43,7 +43,7 @@ class ChatInputRow extends StatelessWidget {
           );
         }
         return Row(
-          crossAxisAlignment: CrossAxisAlignment.end,
+          crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: controller.selectMode
               ? <Widget>[
@@ -317,11 +317,9 @@ class ChatInputRow extends StatelessWidget {
                         focusNode: controller.inputFocus,
                         controller: controller.sendController,
                         decoration: InputDecoration(
-                          contentPadding: const EdgeInsets.only(
-                            left: 6.0,
-                            right: 6.0,
-                            bottom: 10.0,
-                            top: 0.0,
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 6.0,
+                            vertical: 10.0,
                           ),
                           counter: const SizedBox.shrink(),
                           hintText: L10n.of(context).writeAMessage,

--- a/lib/pages/chat/input_bar.dart
+++ b/lib/pages/chat/input_bar.dart
@@ -448,6 +448,7 @@ class InputBar extends StatelessWidget {
         keyboardType: keyboardType,
         textInputAction: textInputAction,
         autofocus: autofocus!,
+        spellCheckConfiguration: const SpellCheckConfiguration(),
         inputFormatters: [
           LengthLimitingTextInputFormatter((maxPDUSize / 3).floor()),
         ],


### PR DESCRIPTION
This PR enables Flutter's native spell checking for the chat input field by adding a `SpellCheckConfiguration` to the message `TextField`.

### Why

This allows users to benefit from the operating system's built-in spell checker, improving the typing experience and helping catch typos before sending messages.

### Changes

* Enable native spell checking by setting:

  ```dart
  spellCheckConfiguration: const SpellCheckConfiguration(),
  ```

  on the chat input `TextField`.

### Testing

Tested on:

* [x] Android

Not tested on:

* [ ] iOS
* [ ] Browser (Chromium based)
* [ ] Browser (Firefox based)
* [ ] Browser (WebKit based)
* [ ] Desktop Linux
* [ ] Desktop Windows
* [ ] Desktop macOS