### PR TITLE
Add: SpellCheck & TextCapitalization in optionalMessage

### DIFF
--- a/lib/pages/chat/send_file_dialog.dart
+++ b/lib/pages/chat/send_file_dialog.dart
@@ -477,7 +477,8 @@ class SendFileDialogState extends State<SendFileDialog> {
                         labelText: L10n.of(context).optionalMessage,
                         keyboardType: .multiline,
                         textCapitalization: TextCapitalization.sentences,
-                        spellCheckConfiguration: const SpellCheckConfiguration(),
+                        spellCheckConfiguration:
+                            const SpellCheckConfiguration(),
                         maxLength: 4096,
                         counterText: '',
                         textInputAction: AppSettings.sendOnEnter.value

--- a/lib/pages/chat/send_file_dialog.dart
+++ b/lib/pages/chat/send_file_dialog.dart
@@ -477,8 +477,10 @@ class SendFileDialogState extends State<SendFileDialog> {
                         labelText: L10n.of(context).optionalMessage,
                         keyboardType: .multiline,
                         textCapitalization: TextCapitalization.sentences,
-                        spellCheckConfiguration:
-                            const SpellCheckConfiguration(),
+                        spellCheckConfiguration: SpellCheckConfiguration(
+                          spellCheckSuggestionsToolbarBuilder:
+                              (context, state) => const SizedBox.shrink(),
+                        ),
                         maxLength: 4096,
                         counterText: '',
                         textInputAction: AppSettings.sendOnEnter.value

--- a/lib/pages/chat/send_file_dialog.dart
+++ b/lib/pages/chat/send_file_dialog.dart
@@ -476,6 +476,8 @@ class SendFileDialogState extends State<SendFileDialog> {
                         controller: _labelTextController,
                         labelText: L10n.of(context).optionalMessage,
                         keyboardType: .multiline,
+                        textCapitalization: TextCapitalization.sentences,
+                        spellCheckConfiguration: const SpellCheckConfiguration(),
                         maxLength: 4096,
                         counterText: '',
                         textInputAction: AppSettings.sendOnEnter.value

--- a/lib/widgets/adaptive_dialogs/dialog_text_field.dart
+++ b/lib/widgets/adaptive_dialogs/dialog_text_field.dart
@@ -19,6 +19,8 @@ class DialogTextField extends StatelessWidget {
   final TextInputType? keyboardType;
   final int? maxLength;
   final bool autocorrect = true;
+  final TextCapitalization textCapitalization;
+  final SpellCheckConfiguration? spellCheckConfiguration;
   final void Function(String)? onSubmitted;
   final TextInputAction? textInputAction;
 
@@ -38,6 +40,8 @@ class DialogTextField extends StatelessWidget {
     this.errorText,
     this.obscureText = false,
     this.readOnly = false,
+    this.textCapitalization = TextCapitalization.none,
+    this.spellCheckConfiguration = const SpellCheckConfiguration.disabled(),
     this.textStyle,
     this.textInputAction,
     this.onSubmitted,
@@ -64,6 +68,8 @@ class DialogTextField extends StatelessWidget {
           maxLength: maxLength,
           keyboardType: keyboardType,
           autocorrect: autocorrect,
+          textCapitalization: textCapitalization,
+          spellCheckConfiguration: spellCheckConfiguration,
           textInputAction: textInputAction,
           onSubmitted: onSubmitted,
           decoration: InputDecoration(


### PR DESCRIPTION
**What has been changed:**
Enabled automatic text capitalization and spell-checking features for the optional message input field used when sending media files.

**Why it has been changed:**
To improve the user experience (UX) and typing convenience. Users can now see spelling errors highlighted and start sentences with capital letters automatically, making the optional message field consistent with the main chat input.

**How it has been changed:**
Updated the configuration properties of the text field component responsible for the optionalMessage input, setting spellCheckConfiguration and textCapitalization parameters to active/sentences.

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS