### PR TITLE
Fix: Viewer closes accidentally during zoom

### DIFF
--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -207,11 +207,10 @@ class _ZoomableImageState extends State<_ZoomableImage> {
       },
       // When interaction ends, check if we are still zoomed in
       onInteractionEnd: (details) {
-        widget.controller.onInteractionEnds(details);
-
         // Identity matrix means scale is 1.0 and offset is 0,0
         final isZoomed = _transformController.value.row0[0] != 1.0;
         if (!isZoomed) {
+          widget.controller.onInteractionEnds(details);
           widget.onZoomStatusChanged(false);
         }
       },


### PR DESCRIPTION
**What has been changed:**
Disabled or restricted the swipe-to-close gesture in the media viewer while the user is actively zooming or panning an image.

**Why it has been changed:**
To fix a bug where pinching to zoom or panning around a magnified image accidentally triggered the swipe-down/swipe-up gesture, closing the viewer abruptly and frustrating the user.


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS