### PR TITLE
Fix: Preserve newlines in formatted text messages

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -248,7 +248,7 @@ class _HtmlMessageState extends State<HtmlMessage> {
         return const TextSpan();
       }
 
-      text = text.replaceAll(RegExp(r'\s+'), ' ');
+      text = text.replaceAll(RegExp(r'[ \t\r\f]+'), ' ');
       if (text.isEmpty) return const TextSpan();
 
       return insideAnchor


### PR DESCRIPTION
**What has been changed:**
Updated the regular expression used for text normalization to prevent it from replacing newline (\n) characters with standard spaces.

**Why it has been changed:**
To fix a bug where formatted messages lost all line breaks and collapsed into a single line of text, which severely broke text readability and layout.

**How it has been changed:**
Replaced the aggressive RegExp(r'\s+') pattern, which matches all whitespace including newlines, with RegExp(r'[ \t\r\f]+'). This explicitly limits white space normalization to tabs and horizontal spaces, preserving \n intact.

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS