### PR TITLE
Video thumbnail

### DIFF
--- a/lib/pages/chat/events/video_player.dart
+++ b/lib/pages/chat/events/video_player.dart
@@ -46,9 +46,7 @@ class EventVideoPlayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final supportsVideoPlayer = PlatformInfos.supportsVideoPlayer;
-
-    final hardCorner = Radius.circular(2);
+    final hardCorner = const Radius.circular(2);
     final roundedCorner = Radius.circular(AppConfig.borderRadius - 2);
 
     var borderRadius = BorderRadius.all(roundedCorner);
@@ -140,38 +138,55 @@ class EventVideoPlayer extends StatelessWidget {
                 aspectRatio: aspectRatio,
                 child: Stack(
                   children: [
-                    if (event.hasThumbnail && loadThumbnail)
-                      MxcImage(
-                        event: event,
-                        uri: event.thumbnailMxcUrl,
-                        isThumbnail: true,
-                        width: bubbleWidth,
-                        // height: width * aspectRatio,
-                        fit: BoxFit.cover,
-                        placeholder: (context) => LayoutBuilder(
-                          builder: (context, constraints) => BlurHash(
+                    event.hasThumbnail && loadThumbnail
+                        ? MxcImage(
+                            event: event,
+                            isThumbnail: true,
+                            width: bubbleWidth,
+                            fit: BoxFit.cover,
+                            placeholder: (context) => LayoutBuilder(
+                              builder: (context, constraints) => BlurHash(
+                                blurhash: blurHash,
+                                width: constraints.maxWidth,
+                                height: constraints.maxHeight,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                          )
+                        : BlurHash(
                             blurhash: blurHash,
-                            width: constraints.maxWidth,
-                            height: constraints.maxHeight,
+                            width: bubbleWidth,
+                            height: bubbleWidth / aspectRatio,
                             fit: BoxFit.cover,
                           ),
+                    if (duration != null || sizeInt != null)
+                      Positioned(
+                        bottom: 3,
+                        left: 4,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: Colors.black.withValues(alpha: 0.35),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Padding(
+                            padding: const .symmetric(
+                              horizontal: 6,
+                              vertical: 2,
+                            ),
+                            child: Text(
+                              '${duration != null ? '${duration.inMinutes.toString().padLeft(2, '0')}:${(duration.inSeconds % 60).toString().padLeft(2, '0')}' : ''}${duration != null && sizeInt != null ? ' • ' : ''}${sizeInt?.sizeString ?? ''}',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 11,
+                                height: 1.0,
+                              ),
+                            ),
+                          ),
                         ),
-                      )
-                    else
-                      BlurHash(
-                        blurhash: blurHash,
-                        width: bubbleWidth,
-                        height: bubbleWidth * aspectRatio,
-                        fit: BoxFit.cover,
                       ),
                     Center(
-                      // child: CircleAvatar(
-                      //   child: supportsVideoPlayer
-                      //       ? const Icon(Icons.play_arrow_outlined)
-                      //       : const Icon(Icons.file_download_outlined),
-                      // ),
-                      child: FilledButton.tonal(
-                        onPressed: () => supportsVideoPlayer
+                      child: IconButton.filledTonal(
+                        onPressed: () => PlatformInfos.supportsVideoPlayer
                             ? showDialog(
                                 context: context,
                                 useRootNavigator: false,
@@ -182,38 +197,12 @@ class EventVideoPlayer extends StatelessWidget {
                                 ),
                               )
                             : event.saveFile(context),
-                        child: Row(
-                          mainAxisSize: .min,
-                          children: [
-                            supportsVideoPlayer
-                                ? const Icon(Icons.play_arrow_outlined)
-                                : const Icon(Icons.file_download_outlined),
-                            const SizedBox(width: 12),
-                            Text(
-                              supportsVideoPlayer
-                                  ? sizeInt == null
-                                        ? L10n.of(context).playVideoNoSize
-                                        : sizeInt.sizeString
-                                  : sizeInt == null
-                                  ? L10n.of(context).downloadVideoNoSize
-                                  : sizeInt.sizeString,
-                            ),
-                          ],
+                        style: IconButton.styleFrom(
+                          backgroundColor: Colors.black.withValues(alpha: 0.6),
                         ),
+                        icon: const Icon(Icons.play_arrow_outlined),
                       ),
                     ),
-                    if (duration != null)
-                      Positioned(
-                        bottom: 8,
-                        left: 16,
-                        child: Text(
-                          '${duration.inMinutes.toString().padLeft(2, '0')}:${(duration.inSeconds % 60).toString().padLeft(2, '0')}',
-                          style: TextStyle(
-                            color: Colors.white,
-                            backgroundColor: Colors.black.withAlpha(32),
-                          ),
-                        ),
-                      ),
                   ],
                 ),
               ),

--- a/lib/pages/chat/events/video_player.dart
+++ b/lib/pages/chat/events/video_player.dart
@@ -46,6 +46,7 @@ class EventVideoPlayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final supportsVideoPlayer = PlatformInfos.supportsVideoPlayer;
     final hardCorner = const Radius.circular(2);
     final roundedCorner = Radius.circular(AppConfig.borderRadius - 2);
 
@@ -186,7 +187,7 @@ class EventVideoPlayer extends StatelessWidget {
                       ),
                     Center(
                       child: IconButton.filledTonal(
-                        onPressed: () => PlatformInfos.supportsVideoPlayer
+                        onPressed: () => supportsVideoPlayer
                             ? showDialog(
                                 context: context,
                                 useRootNavigator: false,
@@ -200,7 +201,15 @@ class EventVideoPlayer extends StatelessWidget {
                         style: IconButton.styleFrom(
                           backgroundColor: Colors.black.withValues(alpha: 0.6),
                         ),
-                        icon: const Icon(Icons.play_arrow_outlined),
+                        icon: supportsVideoPlayer
+                            ? const Icon(
+                                Icons.play_arrow_outlined,
+                                color: Colors.white,
+                              )
+                            : const Icon(
+                                Icons.file_download_outlined,
+                                color: Colors.white,
+                              ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
**What:** Replaced the nested `if-else` widget structure with a clean ternary conditional expression to render `MxcImage` correctly, fixed the fallback `BlurHash` aspect ratio rendering formula, grouped the duration and file size inside a single styled corner badge, and updated the action button to a custom translucent `IconButton.filledTonal`.

**Why:** The fallback blurred layout suffered from a broken height computation, causing layout distortion. Additionally, combining metadata overlay information saves vertical bubble space and provides a polished design matching modern chat interfaces.

**How:**

- Fixed the fallback `BlurHash` height definition from `bubbleWidth * aspectRatio` to `bubbleWidth / aspectRatio`.
- Grouped the duration text and the conditional `sizeInt?.sizeString` into a unified string separated by a bullet (•), placed inside a single `Positioned` container with custom padding and background transparency.
- Replaced the text-based button with a centered, translucent `IconButton.filledTonal` using a hardcoded `Icons.play_arrow_outlined` icon

<img width="278" height="410" alt="изображение" src="https://github.com/user-attachments/assets/8456d697-1976-45e8-b7f6-fa55d661223d" />

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS