### PR TITLE
Refactor: Remove convertLinebreaksInFormatting to support line breaks

### DIFF
--- a/lib/pages/chat/send_file_dialog.dart
+++ b/lib/pages/chat/send_file_dialog.dart
@@ -60,9 +60,6 @@ class SendFileDialogState extends State<SendFileDialog> {
   Future<void> _send() async {
     final scaffoldMessenger = ScaffoldMessenger.of(widget.outerContext);
     final l10n = L10n.of(context);
-    final convertLinebreaks = Matrix.of(
-      context,
-    ).client.convertLinebreaksInFormatting;
 
     try {
       setState(() {
@@ -162,7 +159,6 @@ class SendFileDialogState extends State<SendFileDialog> {
             getEmotePacks: () =>
                 widget.room.getImagePacksFlat(ImagePackUsage.emoticon),
             getMention: widget.room.getMention,
-            convertLinebreaks: convertLinebreaks,
           );
 
           // if the decoded html is the same as the body, there is no need in sending a formatted message

--- a/lib/utils/client_manager.dart
+++ b/lib/utils/client_manager.dart
@@ -148,7 +148,6 @@ abstract class ClientManager {
       shareKeysWith:
           .values.singleWhereOrNull((share) => share.name == shareKeysWith) ??
           .crossVerifiedIfEnabled,
-      convertLinebreaksInFormatting: false,
       onSoftLogout: enableSoftLogout
           ? (client) => client.refreshAccessToken()
           : null,


### PR DESCRIPTION
**What:** Removed the global configuration parameter `convertLinebreaksInFormatting` that was explicitly disabling the conversion of `\n` into `<br/>` HTML tags.

**Why:** When this parameter was active, line breaks from the original markdown text were ignored or stripped during HTML parsing, resulting in poorly structured and unreadable formatted messages.


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS