### PR TITLE
Disable default spell check suggestions toolbar

### DIFF
--- a/lib/pages/chat/input_bar.dart
+++ b/lib/pages/chat/input_bar.dart
@@ -448,7 +448,10 @@ class InputBar extends StatelessWidget {
         keyboardType: keyboardType,
         textInputAction: textInputAction,
         autofocus: autofocus!,
-        spellCheckConfiguration: const SpellCheckConfiguration(),
+        spellCheckConfiguration: SpellCheckConfiguration(
+          spellCheckSuggestionsToolbarBuilder: (context, state) =>
+              const SizedBox.shrink(),
+        ),
         inputFormatters: [
           LengthLimitingTextInputFormatter((maxPDUSize / 3).floor()),
         ],


### PR DESCRIPTION
**What:** Disabled the default native platform spell check suggestions pop-up toolbar on text inputs.

**Why:** The native toolbar was aesthetically unpleasant, visually blocked the typed text, and made cursor navigation and manual text editing highly inconvenient.

**How:** Provided a custom `SpellCheckConfiguration` to the input field, overriding `spellCheckSuggestionsToolbarBuilder` to completely hide the menu layout by returning an empty `SizedBox.shrink()`.

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS